### PR TITLE
Bump version, add HTTPS fix

### DIFF
--- a/src/install.rdf
+++ b/src/install.rdf
@@ -9,7 +9,7 @@
   <RDF:Description RDF:about="urn:mozilla:install-manifest"
                    em:id="socialite@chromakode"
                    em:name="Socialite"
-                   em:version="1.5.1"
+                   em:version="1.5.3"
                    em:type="2"
                    em:iconURL="chrome://socialite/skin/socialite.png"
                    em:optionsURL="chrome://socialite/content/socialitePreferences.xul">

--- a/src/modules/site.jsm
+++ b/src/modules/site.jsm
@@ -113,8 +113,8 @@ SiteCollection.prototype.initRefreshInterval = function() {
 SiteCollection.prototype.onContentLoad = function(doc, win) {
   if (doc.location) {
     for (let [siteID, site] in this) {
-      // Remove www.
-      var baseRegex = /www\.?/;
+      // Remove https?://www.
+      var baseRegex = /https?:\/\/www\.?/;
       var baseSiteHost = site.siteURI.spec.replace(baseRegex, "");
       var baseURL = doc.location.href.replace(baseRegex, "");
       if (strStartsWith(baseURL, baseSiteHost)) {


### PR DESCRIPTION
This adds the HTTPS fixes from Socialite 1.5.2
(https://www.reddit.com/r/socialite/comments/2furqf/seems_like_the_new_https_option_rolled_out_today/cke39ns,
not on GitHub) and bumps the version number to 1.5.3
